### PR TITLE
feat: expand amenities data

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -275,7 +275,19 @@
   ,
   "amenities": { "message": "Amenities" },
   "schoolsInNeighbourhood": { "message": "Schools in neighbourhood" },
-  "avgDistanceToSchools": { "message": "Avg. distance to schools" }
+  "avgDistanceToSchools": { "message": "Avg. distance to schools" },
+  "gpsInNeighbourhood": { "message": "GPs in neighbourhood" },
+  "avgDistanceToGps": { "message": "Avg. distance to GP" },
+  "afterSchoolCareInNeighbourhood": { "message": "After school care in neighbourhood" },
+  "avgDistanceToAfterSchoolCare": { "message": "Avg. distance to after school care" },
+  "daycareInNeighbourhood": { "message": "Day care in neighbourhood" },
+  "avgDistanceToDaycare": { "message": "Avg. distance to day care" },
+  "restaurantsInNeighbourhood": { "message": "Restaurants in neighbourhood" },
+  "avgDistanceToRestaurants": { "message": "Avg. distance to restaurants" },
+  "supermarketsInNeighbourhood": { "message": "Supermarkets in neighbourhood" },
+  "avgDistanceToSupermarkets": { "message": "Avg. distance to supermarkets" },
+  "cafesInNeighbourhood": { "message": "Cafes in neighbourhood" },
+  "avgDistanceToCafes": { "message": "Avg. distance to cafes" }
   ,
   "loadingNeighbourhood": { "message": "Loading neighbourhood data…" }
   ,

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -275,7 +275,19 @@
   ,
   "amenities": { "message": "Voorzieningen" },
   "schoolsInNeighbourhood": { "message": "Scholen in de buurt" },
-  "avgDistanceToSchools": { "message": "Gem. afstand tot scholen" }
+  "avgDistanceToSchools": { "message": "Gem. afstand tot scholen" },
+  "gpsInNeighbourhood": { "message": "Huisartsen in de buurt" },
+  "avgDistanceToGps": { "message": "Gem. afstand tot huisarts" },
+  "afterSchoolCareInNeighbourhood": { "message": "Buitenschoolse opvang in de buurt" },
+  "avgDistanceToAfterSchoolCare": { "message": "Gem. afstand tot buitenschoolse opvang" },
+  "daycareInNeighbourhood": { "message": "Kinderopvang in de buurt" },
+  "avgDistanceToDaycare": { "message": "Gem. afstand tot kinderopvang" },
+  "restaurantsInNeighbourhood": { "message": "Restaurants in de buurt" },
+  "avgDistanceToRestaurants": { "message": "Gem. afstand tot restaurants" },
+  "supermarketsInNeighbourhood": { "message": "Supermarkten in de buurt" },
+  "avgDistanceToSupermarkets": { "message": "Gem. afstand tot supermarkten" },
+  "cafesInNeighbourhood": { "message": "Cafés in de buurt" },
+  "avgDistanceToCafes": { "message": "Gem. afstand tot cafés" }
   ,
   "loadingNeighbourhood": { "message": "Buurtgegevens laden…" }
   ,

--- a/src/common/viewableProperties.js
+++ b/src/common/viewableProperties.js
@@ -39,6 +39,126 @@ export const VIEWABLE_PROPERTIES = [
     },
   },
   {
+    name: "gpsInNeighbourhood",
+    group: "amenities",
+    valueFormat: (apiField, properties) => {
+      const obj = properties["gpsInNeighbourhood"];
+      const v = obj && obj.value;
+      return typeof v === "number" ? `${v}` : chrome.i18n.getMessage("noInfo");
+    },
+  },
+  {
+    name: "avgDistanceToGps",
+    group: "amenities",
+    valueFormat: (apiField, properties) => {
+      const obj = properties["avgDistanceToGps"];
+      const v = obj && obj.value;
+      if (typeof v !== "number" || !(isFinite(v))) return chrome.i18n.getMessage("noInfo");
+      if (v >= 1000) return `${(v / 1000).toFixed(1)} km`;
+      return `${v} m`;
+    },
+  },
+  {
+    name: "afterSchoolCareInNeighbourhood",
+    group: "amenities",
+    valueFormat: (apiField, properties) => {
+      const obj = properties["afterSchoolCareInNeighbourhood"];
+      const v = obj && obj.value;
+      return typeof v === "number" ? `${v}` : chrome.i18n.getMessage("noInfo");
+    },
+  },
+  {
+    name: "avgDistanceToAfterSchoolCare",
+    group: "amenities",
+    valueFormat: (apiField, properties) => {
+      const obj = properties["avgDistanceToAfterSchoolCare"];
+      const v = obj && obj.value;
+      if (typeof v !== "number" || !(isFinite(v))) return chrome.i18n.getMessage("noInfo");
+      if (v >= 1000) return `${(v / 1000).toFixed(1)} km`;
+      return `${v} m`;
+    },
+  },
+  {
+    name: "daycareInNeighbourhood",
+    group: "amenities",
+    valueFormat: (apiField, properties) => {
+      const obj = properties["daycareInNeighbourhood"];
+      const v = obj && obj.value;
+      return typeof v === "number" ? `${v}` : chrome.i18n.getMessage("noInfo");
+    },
+  },
+  {
+    name: "avgDistanceToDaycare",
+    group: "amenities",
+    valueFormat: (apiField, properties) => {
+      const obj = properties["avgDistanceToDaycare"];
+      const v = obj && obj.value;
+      if (typeof v !== "number" || !(isFinite(v))) return chrome.i18n.getMessage("noInfo");
+      if (v >= 1000) return `${(v / 1000).toFixed(1)} km`;
+      return `${v} m`;
+    },
+  },
+  {
+    name: "restaurantsInNeighbourhood",
+    group: "amenities",
+    valueFormat: (apiField, properties) => {
+      const obj = properties["restaurantsInNeighbourhood"];
+      const v = obj && obj.value;
+      return typeof v === "number" ? `${v}` : chrome.i18n.getMessage("noInfo");
+    },
+  },
+  {
+    name: "avgDistanceToRestaurants",
+    group: "amenities",
+    valueFormat: (apiField, properties) => {
+      const obj = properties["avgDistanceToRestaurants"];
+      const v = obj && obj.value;
+      if (typeof v !== "number" || !(isFinite(v))) return chrome.i18n.getMessage("noInfo");
+      if (v >= 1000) return `${(v / 1000).toFixed(1)} km`;
+      return `${v} m`;
+    },
+  },
+  {
+    name: "supermarketsInNeighbourhood",
+    group: "amenities",
+    valueFormat: (apiField, properties) => {
+      const obj = properties["supermarketsInNeighbourhood"];
+      const v = obj && obj.value;
+      return typeof v === "number" ? `${v}` : chrome.i18n.getMessage("noInfo");
+    },
+  },
+  {
+    name: "avgDistanceToSupermarkets",
+    group: "amenities",
+    valueFormat: (apiField, properties) => {
+      const obj = properties["avgDistanceToSupermarkets"];
+      const v = obj && obj.value;
+      if (typeof v !== "number" || !(isFinite(v))) return chrome.i18n.getMessage("noInfo");
+      if (v >= 1000) return `${(v / 1000).toFixed(1)} km`;
+      return `${v} m`;
+    },
+  },
+  {
+    name: "cafesInNeighbourhood",
+    group: "amenities",
+    valueFormat: (apiField, properties) => {
+      const obj = properties["cafesInNeighbourhood"];
+      const v = obj && obj.value;
+      return typeof v === "number" ? `${v}` : chrome.i18n.getMessage("noInfo");
+    },
+  },
+  {
+    name: "avgDistanceToCafes",
+    group: "amenities",
+    valueFormat: (apiField, properties) => {
+      const obj = properties["avgDistanceToCafes"];
+      const v = obj && obj.value;
+      if (typeof v !== "number" || !(isFinite(v))) return chrome.i18n.getMessage("noInfo");
+      if (v >= 1000) return `${(v / 1000).toFixed(1)} km`;
+      return `${v} m`;
+    },
+  },
+  {
     name: "municipalityName",
     group: "doNotShowInTable",
   },


### PR DESCRIPTION
## Summary
- expand amenity stats to include doctors, childcare, daycare, restaurants, supermarkets and cafes
- show new amenity counts and distances in neighbourhood view

## Testing
- `npm test` *(fails: Browser is not downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68b2280a60648326888c04f72e4acbcd