### PR TITLE
feat(options): add language selector

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -11,6 +11,15 @@
   "selectBadges": {
     "message": "Select badges visible at the top of the property page"
   },
+  "selectLanguage": {
+    "message": "Select language"
+  },
+  "english": {
+    "message": "English"
+  },
+  "dutch": {
+    "message": "Dutch"
+  },
   "doNotShowInTable": {
     "message": ""
   },

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -11,6 +11,15 @@
   "selectBadges": {
     "message": "Selecteer badges die zichtbaar zijn bovenaan de optiespagina"
   },
+  "selectLanguage": {
+    "message": "Selecteer taal"
+  },
+  "english": {
+    "message": "Engels"
+  },
+  "dutch": {
+    "message": "Nederlands"
+  },
   "doNotShowInTable": {
     "message": ""
   },

--- a/src/common/readUserSettings.js
+++ b/src/common/readUserSettings.js
@@ -4,6 +4,6 @@ export async function readUserSettings() {
   const viewablePropertiesName = VIEWABLE_PROPERTIES.map(({ name }) => name);
 
   return new Promise(resolve => {
-    chrome.storage.sync.get(viewablePropertiesName, resolve);
+    chrome.storage.sync.get([...viewablePropertiesName, "language"], resolve);
   });
 }

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -20,6 +20,12 @@
   margin-right: 6px;
 }
 
+.options-page-select-container {
+  margin-left: 6px;
+  display: flex;
+  align-items: center;
+}
+
 .options-page-checkbox,
 .options-page-label {
   cursor: pointer;

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -5,6 +5,7 @@
   </head>
   <body>
     <h3 id="header"></h3>
+    <div id="language-switch"></div>
     <div id="options-table"></div>
   </body>
   <script src="boot.js"></script>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -7,7 +7,11 @@ initializePage();
 async function initializePage() {
   const userSettings = await readUserSettings();
 
+  const defaultLanguage = chrome.i18n.getUILanguage().startsWith("nl") ? "nl" : "en";
+  const selectedLanguage = userSettings.language || defaultLanguage;
+
   const headerHtml = makeHeaderHtml();
+  const languageSwitchHtml = makeLanguageSwitchHtml(selectedLanguage);
   const optionsTableHtml = makeOptionsTableHtml(userSettings);
 
   document
@@ -15,14 +19,46 @@ async function initializePage() {
     .insertAdjacentHTML("afterbegin", headerHtml);
 
   document
+    .getElementById("language-switch")
+    .insertAdjacentHTML("afterbegin", languageSwitchHtml);
+
+  document
     .getElementById("options-table")
     .insertAdjacentHTML("afterbegin", optionsTableHtml);
 
   document.addEventListener("click", handleClicks);
+
+  document
+    .getElementById("language-switch-select")
+    .addEventListener("change", handleLanguageChange);
 }
 
 function makeHeaderHtml() {
   return `<h3>${chrome.i18n.getMessage("selectBadges")}</h3>`;
+}
+
+function makeLanguageSwitchHtml(selectedLanguage) {
+  const languageLabel = chrome.i18n.getMessage("selectLanguage");
+  const englishLabel = chrome.i18n.getMessage("english");
+  const dutchLabel = chrome.i18n.getMessage("dutch");
+  const enSelected = selectedLanguage === "en" ? "selected" : "";
+  const nlSelected = selectedLanguage === "nl" ? "selected" : "";
+
+  return `
+    <div class="options-page-row">
+      <div class="options-page-label-container">
+        <label class="options-page-label" for="language-switch-select">
+          ${languageLabel}
+        </label>
+      </div>
+      <div class="options-page-select-container">
+        <select id="language-switch-select" data-test="languageSelect">
+          <option value="en" ${enSelected}>${englishLabel}</option>
+          <option value="nl" ${nlSelected}>${dutchLabel}</option>
+        </select>
+      </div>
+    </div>
+  `;
 }
 
 function makeOptionsTableHtml(userSettings) {
@@ -78,6 +114,10 @@ function handleClicks(event) {
   if (isOptionClick) {
     chrome.storage.sync.set({ [clickedOptionName]: clickedElement.checked });
   }
+}
+
+function handleLanguageChange(event) {
+  chrome.storage.sync.set({ language: event.target.value });
 }
 
 function makeSectionHeaderHtml(groupName) {

--- a/tests/jest-puppeteer.config.js
+++ b/tests/jest-puppeteer.config.js
@@ -4,8 +4,13 @@ const pathToExtension = path.resolve("./build");
 
 module.exports = {
   launch: {
-    headless: false,
-    args: [`--disable-extensions-except=${pathToExtension}`, `--load-extension=${pathToExtension}`],
+    headless: true,
+    args: [
+      "--no-sandbox",
+      "--disable-setuid-sandbox",
+      `--disable-extensions-except=${pathToExtension}`,
+      `--load-extension=${pathToExtension}`,
+    ],
     /* "executablePath" - set by Docker container on CI, not used locally */
     executablePath: process.env.PUPPETEER_EXEC_PATH,
   },

--- a/tests/specs/propertyPage.spec.js
+++ b/tests/specs/propertyPage.spec.js
@@ -160,9 +160,9 @@ describe("Options page", () => {
     expect(allPropertyNames).toEqual(renderedPropertyNames);
   });
 
-  it("Default options should be selected", async () => {
-    const selectedOptions = await page.$$eval("[data-test^=optionsPagePropertyCheckbox]", checkboxElements => {
-      const selectedCheckboxElements = checkboxElements.filter(({ checked }) => checked);
+    it("Default options should be selected", async () => {
+      const selectedOptions = await page.$$eval("[data-test^=optionsPagePropertyCheckbox]", checkboxElements => {
+        const selectedCheckboxElements = checkboxElements.filter(({ checked }) => checked);
 
       const selectedCheckboxNames = selectedCheckboxElements
         .map(({ dataset }) => dataset.test)
@@ -171,8 +171,25 @@ describe("Options page", () => {
       return selectedCheckboxNames;
     });
 
-    expect(selectedOptions).toEqual(["neighbourhoodName", "meanIncomePerResident"]);
-  });
+      expect(selectedOptions).toEqual(["neighbourhoodName", "meanIncomePerResident"]);
+    });
+
+    it("Options page has language selector", async () => {
+      const options = await page.$$eval(
+        "[data-test=languageSelect] option",
+        optionElements => optionElements.map(({ value }) => value)
+      );
+      expect(options).toEqual(["en", "nl"]);
+
+      const selectedLanguage = await page.$eval(
+        "[data-test=languageSelect]",
+        selectElement => selectElement.value
+      );
+      const defaultLanguage = await page.evaluate(() =>
+        chrome.i18n.getUILanguage().startsWith("nl") ? "nl" : "en"
+      );
+      expect(selectedLanguage).toBe(defaultLanguage);
+    });
 
   it("User should see selected badges", async () => {
     // Un-select default "neighbourhood name" badge


### PR DESCRIPTION
## Summary
- add language selector to options menu and store choice
- localize labels for Dutch and English
- test for language selector and adjust puppeteer launch config

## Testing
- `npm test` *(fails: Jest globalSetup unable to launch browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b22e1ccbbc8326b1490572aa12025f